### PR TITLE
#41: Fix crash when doing shield game height check

### DIFF
--- a/gamemode/wareminigames/shield.lua
+++ b/gamemode/wareminigames/shield.lua
@@ -138,12 +138,12 @@ end
 function WARE:Think()
 	for k,v in pairs(team.GetPlayers(TEAM_HUMANS)) do 
 		if v:GetPos().z < self.zlimit then
-			ent:StripWeapons()
+			v:StripWeapons()
 			v:ApplyLose()
 			v:SimulateDeath()
 			
 			for k,npc in pairs( self.SpawnedNPCs ) do
-				npc:AddEntityRelationship( ent, D_NU, 99 )
+				npc:AddEntityRelationship(v, D_NU, 99 )
 			end
 			
 		end


### PR DESCRIPTION
Seems to be a copy-paste error. ent is not defined in the Think() method, should be v.